### PR TITLE
Use header-based authorization instead of url-based

### DIFF
--- a/src/YaMetrika.php
+++ b/src/YaMetrika.php
@@ -431,7 +431,7 @@ class YaMetrika
      */
     private function query($params)
     {
-        $url = $this->endPoint . '?' . http_build_query(array_merge($params, ['ids' => $this->counterId, 'oauth_token' => $this->token]), null, '&');
+        $url = $this->endPoint . '?' . http_build_query(array_merge($params, ['ids' => $this->counterId]), null, '&');
 
         try {
             $client = new GuzzleClient($this->getHttpClientParams());
@@ -466,8 +466,15 @@ class YaMetrika
      */
     private function getHttpClientParams()
     {
-        $params = [];
-        if ($this->proxy) $params[RequestOptions::PROXY] = $this->proxy;
+        $params = [
+            RequestOptions::HEADERS => [
+                "Authorization" => "OAuth {$this->token}"
+            ]
+        ];
+
+        if ($this->proxy) {
+            $params[RequestOptions::PROXY] = $this->proxy;
+        }
 
         return $params;
     }


### PR DESCRIPTION
I've got an email:

> Your apps pass API authorization token in URL parameters. This authorization type will no longer be available starting 13 February 2019.

so I propose change to library